### PR TITLE
Improve export mechanism

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,4 +159,9 @@ function reset(){
         });
 }
 
-export default {stub, requireWithStubs, require, reset};
+module.exports = {
+    stub: stub,
+    requireWithStubs: requireWithStubs,
+    require: require,
+    reset: reset
+};

--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ function preserveIfDefined(normalizedName){
 
 function preserveDefinition(normalizedName){
     return System.import(normalizedName).then(function(originalModule){
-        originals[normalizedName] = originalModule;
-        return originalModule;
+        originals[normalizedName] = System.get(normalizedName);
+        return originals[normalizedName];
     });
 }
 
@@ -85,20 +85,39 @@ function addNormalizedName(stub, i) {
     });
 }
 
+function getReplacementModule(originalModule, stub) {
+    var implementation = stub.implementation;
+    var moduleDef;
+
+    switch (typeof implementation) {
+        case 'object':
+            moduleDef = implementation;
+            break;
+        case 'function':
+            moduleDef = Object.keys(implementation).reduce(function (acc, key) {
+                acc[key] = implementation[key];
+                return acc;
+            }, {
+                default: implementation
+            });
+            break;
+        default:
+            moduleDef = {
+                default: implementation
+            };
+    }
+
+    return System.newModule(moduleDef);
+}
+
 function redefineStubs(){
     return Promise.all(
         stubbed.map(function (stub) {
             var normalizedName = stub.normalizedName;
 
             return preserveDefinition(normalizedName).then(function(originalModule){
-                var exportKeys = Object.keys(originalModule);
-                var hasOnlyDefaultExport = exportKeys.length === 1 && exportKeys[0] === 'default';
-                var newModule = System.newModule(hasOnlyDefaultExport ? {
-                    default: stub.implementation
-                } : stub.implementation);
-
                 System.delete(normalizedName);
-                System.set(normalizedName, newModule);
+                System.set(normalizedName, getReplacementModule(originalModule, stub));
             });
         })
     );

--- a/mocks/common_js_function_with_properties.js
+++ b/mocks/common_js_function_with_properties.js
@@ -1,0 +1,6 @@
+function someFunc() {}
+
+someFunc.a = 'a';
+someFunc.b = 'b';
+
+module.exports = someFunc;

--- a/mocks/imports_common_js_function_with_properties.js
+++ b/mocks/imports_common_js_function_with_properties.js
@@ -1,0 +1,7 @@
+import someFunc from './common_js_function_with_properties.js';
+import {a, b} from './common_js_function_with_properties.js';
+
+export default someFunc
+
+export const exportedA = a;
+export const exportedB = b;

--- a/test.js
+++ b/test.js
@@ -66,6 +66,29 @@ describe('sisyphos', function(){
                 assert.equal(c.getB(), 'such stub');
             });
         });
+
+        it('can stub modules that export functions', function () {
+            var someFunc = function(){};
+
+            someFunc.a = 'newA';
+            someFunc.b = 'newB';
+
+            sisyphos.stub({
+                'mocks/common_js_function_with_properties.js': someFunc
+            });
+
+            return sisyphos.require('mocks/imports_common_js_function_with_properties.js')
+                .then(function (module) {
+                    assert.strictEqual(module.default, someFunc);
+                    return System.normalize('mocks/imports_common_js_function_with_properties.js');
+                })
+                .then(function (normalizedName) {
+                    var module = System.get(normalizedName);
+
+                    assert.equal(module.exportedA, 'newA');
+                    assert.equal(module.exportedB, 'newB');
+                });
+        });
     });
 
     describe('requireWithStubs method', function(){


### PR DESCRIPTION
Improve support for modules with multiple exports.

This fixes a problem that would occurred when one of the stubs is a common.js module whose exported value is a function with additional properties. e.g.:

``` js
//in a.js
function myFunction() {
    ...
}

myFunction.a = 'a';
module.exports = myFunction;


// in b.js
import myFunction from './a.js'
import {a}  from './a.js' // with System.js, this is possible
```

In this case named exports like `a` would not be correctly stubbed.
